### PR TITLE
fix(anchor-js/fabricators): use contract instead of address for cw20 hook message

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ And you can run scripts
 Configurations
 
 - See [.graphqlconfig](.graphqlconfig) file
-    - This configuration is the graphql-config v2 spec (IntelliJ only supports that legacy spec)
-    - See <https://github.com/kamilkisiela/graphql-config/tree/legacy>
+  - This configuration is the graphql-config v2 spec (IntelliJ only supports that legacy spec)
+  - See <https://github.com/kamilkisiela/graphql-config/tree/legacy>
 - See [schema.graphql](schema.graphql) file
   - When the schema file is updated. run `yarn run graphql:update-schema`
 

--- a/packages/src/@anchor-protocol/anchor-js/fabricators/money-market/market-redeem-stable.ts
+++ b/packages/src/@anchor-protocol/anchor-js/fabricators/money-market/market-redeem-stable.ts
@@ -27,7 +27,7 @@ export const fabricateRedeemStable = ({ address, symbol, amount }: Option) => (
   return [
     new MsgExecuteContract(address, aTokenAddress, {
       send: {
-        address: marketAddress,
+        contract: marketAddress,
         amount: new Int(new Dec(amount).mul(1000000)).toString(),
         msg: createHookMsg({
           redeem_stable: {},

--- a/packages/src/@anchor-protocol/anchor-js/fabricators/money-market/provide-collateral.ts
+++ b/packages/src/@anchor-protocol/anchor-js/fabricators/money-market/provide-collateral.ts
@@ -29,9 +29,7 @@ export const fabricateProvideCollateral = ({
   market,
   symbol,
   amount,
-}: Option) => (
-  addressProvider: AddressProvider,
-): MsgExecuteContract[] => {
+}: Option) => (addressProvider: AddressProvider): MsgExecuteContract[] => {
   validateInput([
     validateAddress(address),
     validateWhitelistedMarket(market),
@@ -49,7 +47,7 @@ export const fabricateProvideCollateral = ({
     // provide_collateral call
     new MsgExecuteContract(address, bAssetTokenContract, {
       send: {
-        address: custodyContract,
+        contract: custodyContract,
         amount: new Int(new Dec(amount).mul(1000000)).toString(),
         msg: createHookMsg({
           deposit_collateral: {},


### PR DESCRIPTION
This PR fixes `redeem_stable`, `provide-collateral` messages where cw20 `send` operation used field `address` instead of `contract.