### PR TITLE
Fix: reduce HorizontalScrollTable minWidth for stablecoin-market section

### DIFF
--- a/landing/src/pages/market-simple/index.tsx
+++ b/landing/src/pages/market-simple/index.tsx
@@ -125,7 +125,7 @@ function MarketBase({ className }: MarketProps) {
           </Section>
 
           <Section className="stablecoin-market">
-            <HorizontalScrollTable minWidth={1000}>
+            <HorizontalScrollTable minWidth={900}>
               <colgroup>
                 <col style={{ width: 300 }} />
                 <col style={{ width: 200 }} />


### PR DESCRIPTION
**Description:**
When user is viewing on 13 inch screen (1280px) at the [dashboard](https://anchorprotocol.com/dashboard) page, the `stablecoin-market` section requires horizontal scrolling to view the full `Borrow APR`

**Changes:**
Reduce `HorizontalScrollTable minWidth` from 1000 to 900

**Result:**
_Before Fix:_
<img width="1274" alt="stablecoin_market_before_fix" src="https://user-images.githubusercontent.com/8136256/113131927-61c0db00-9250-11eb-8754-f287755aeb78.png">

_After Fix:_
<img width="1277" alt="stablecoin_market_after_fix" src="https://user-images.githubusercontent.com/8136256/113131977-6be2d980-9250-11eb-89fc-0f841a7ab94f.png">
