### PR TITLE
Feat: enable darkmode for dashboard page

### DIFF
--- a/app/src/components/layouts/CenteredLayout.tsx
+++ b/app/src/components/layouts/CenteredLayout.tsx
@@ -1,4 +1,4 @@
-import { Footer } from 'components/Footer';
+import { Footer } from 'base/components/Footer';
 import { BODY_MARGIN_TOP, screen } from 'env';
 import { ReactNode } from 'react';
 import styled from 'styled-components';

--- a/app/src/components/layouts/PaddedLayout.tsx
+++ b/app/src/components/layouts/PaddedLayout.tsx
@@ -1,4 +1,4 @@
-import { Footer } from 'components/Footer';
+import { Footer } from 'base/components/Footer';
 import { BODY_MARGIN_TOP, screen } from 'env';
 import { ReactNode } from 'react';
 import styled from 'styled-components';

--- a/base/src/base/components/Footer/index.tsx
+++ b/base/src/base/components/Footer/index.tsx
@@ -41,7 +41,7 @@ function FooterBase({ className, style }: FooterProps) {
             {status.network.name.toLowerCase().indexOf('mainnet') !== 0 && (
               <b>[{status.network.name.toUpperCase()}] </b>
             )}
-            Latest Block 2: {lastSyncedHeight}
+            Latest Block: {lastSyncedHeight}
           </IconSpan>
         </a>
       </div>

--- a/base/src/base/components/Footer/index.tsx
+++ b/base/src/base/components/Footer/index.tsx
@@ -13,7 +13,7 @@ import {
   Twitter,
 } from '@material-ui/icons';
 import c from 'color';
-import { screen } from 'env';
+import { screen } from 'base/env';
 import React, { CSSProperties } from 'react';
 import styled from 'styled-components';
 
@@ -41,7 +41,7 @@ function FooterBase({ className, style }: FooterProps) {
             {status.network.name.toLowerCase().indexOf('mainnet') !== 0 && (
               <b>[{status.network.name.toUpperCase()}] </b>
             )}
-            Latest Block: {lastSyncedHeight}
+            Latest Block 2: {lastSyncedHeight}
           </IconSpan>
         </a>
       </div>

--- a/base/src/base/env.ts
+++ b/base/src/base/env.ts
@@ -97,3 +97,15 @@ export const tequilaContractAddresses: AddressMap = {
   vesting: 'terra19f6ktw4qpjj9p9m49y8mhf6pr9807d44xdcus7',
   team: 'terra1x7ted5g0g6ntyqdaqmjwtzcctvvrdju49vs8pl',
 };
+
+export const screen = {
+  mobile: { max: 530 },
+  // mobile : @media (max-width: ${screen.mobile.max}px)
+  tablet: { min: 531, max: 830 },
+  // tablet : @media (min-width: ${screen.tablet.min}px) and (max-width: ${screen.tablet.max}px)
+  pc: { min: 831, max: 1439 },
+  // pc : @media (min-width: ${screen.pc.min}px)
+  monitor: { min: 1440 },
+  // monitor : @media (min-width: ${screen.pc.min}px) and (max-width: ${screen.pc.max}px)
+  // huge monitor : @media (min-width: ${screen.monitor.min}px)
+} as const;

--- a/landing/src/components/Header/index.tsx
+++ b/landing/src/components/Header/index.tsx
@@ -2,15 +2,18 @@ import { DesktopHeader } from 'components/Header/DesktopHeader';
 import { MobileHeader } from 'components/Header/MobileHeader';
 import { useMediaQuery } from 'react-responsive';
 import { useRouteMatch } from 'react-router-dom';
+import { useTheme } from 'base/contexts/theme';
 
 export function Header() {
   const match = useRouteMatch({ path: '/', exact: true });
 
+  const { themeColor } = useTheme();
+
   const isMobile = useMediaQuery({ maxWidth: 700 });
 
   return isMobile ? (
-    <MobileHeader color={!!match ? 'dark' : 'light'} />
+    <MobileHeader color={!!match ? 'dark' : themeColor} />
   ) : (
-    <DesktopHeader color={!!match ? 'dark' : 'light'} />
+    <DesktopHeader color={!!match ? 'dark' : themeColor} />
   );
 }

--- a/landing/src/pages/market-simple/index.tsx
+++ b/landing/src/pages/market-simple/index.tsx
@@ -19,6 +19,7 @@ import { useBAssetMarket } from 'pages/market-simple/queries/bAssetMarket';
 import { useMarket } from 'pages/market-simple/queries/market';
 import { useStableCoinMarket } from 'pages/market-simple/queries/stableCoinMarket';
 import { useMemo } from 'react';
+import { Footer } from 'base/components/Footer';
 import styled from 'styled-components';
 
 export interface MarketProps {
@@ -297,6 +298,7 @@ function MarketBase({ className }: MarketProps) {
             </HorizontalScrollTable>
           </Section>
         </div>
+        <Footer style={{ margin: '60px 0' }} />
       </main>
     </div>
   );


### PR DESCRIPTION
**Description:**
Enable darkmode for [dashboard](https://anchorprotocol.com/dashboard) page

**Changes:**
1. move app footer (`app/src/components/Footer`) to base component (`base/src/base/components/Footer`) for reusing in landing
2. add footer and enable darkmode for dashboard page

**Result:**
_Darkmode:_
<img width="718" alt="dashboard-darkmode" src="https://user-images.githubusercontent.com/8136256/113437482-40f7b180-9419-11eb-8961-89629bbd19d8.png">

_Lightmode:_
<img width="714" alt="dashboard-lightmode" src="https://user-images.githubusercontent.com/8136256/113437502-4ead3700-9419-11eb-8bb1-0a9afa9cd904.png">
