### PR TITLE
Fix: only allow http:// or https:// links on gov poll detail views

### DIFF
--- a/app/src/pages/gov/logics/isLinkHttp.ts
+++ b/app/src/pages/gov/logics/isLinkHttp.ts
@@ -1,0 +1,6 @@
+export function isLinkHttp(link?: string): boolean {
+  return (
+    typeof link === 'string' &&
+    (link.startsWith('http://') || link.startsWith('https://'))
+  );
+}

--- a/app/src/pages/gov/poll.detail.tsx
+++ b/app/src/pages/gov/poll.detail.tsx
@@ -1,3 +1,10 @@
+import {
+  demicrofy,
+  formatANCWithPostfixUnits,
+  formatRate,
+} from '@anchor-protocol/notation';
+import { Rate } from '@anchor-protocol/types';
+import { Schedule } from '@material-ui/icons';
 import { ActionButton } from '@terra-dev/neumorphism-ui/components/ActionButton';
 import { BorderButton } from '@terra-dev/neumorphism-ui/components/BorderButton';
 import { HorizontalHeavyRuler } from '@terra-dev/neumorphism-ui/components/HorizontalHeavyRuler';
@@ -5,18 +12,11 @@ import { HorizontalRuler } from '@terra-dev/neumorphism-ui/components/Horizontal
 import { IconSpan } from '@terra-dev/neumorphism-ui/components/IconSpan';
 import { Section } from '@terra-dev/neumorphism-ui/components/Section';
 import {
-  demicrofy,
-  formatANCWithPostfixUnits,
-  formatRate,
-} from '@anchor-protocol/notation';
-import {
   rulerLightColor,
   rulerShadowColor,
 } from '@terra-dev/styled-neumorphism';
-import { Rate } from '@anchor-protocol/types';
 import { TimeEnd } from '@terra-dev/use-time-end';
 import { useLastSyncedHeight } from 'base/queries/lastSyncedHeight';
-import { Schedule } from '@material-ui/icons';
 import { AccountLink } from 'components/AccountLink';
 import { PaddedLayout } from 'components/layouts/PaddedLayout';
 import { useCodeViewerDialog } from 'components/useCodeViewerDialog';
@@ -31,6 +31,7 @@ import { PollStatusSpan } from 'pages/gov/components/PollStatusSpan';
 import { PollVoters } from 'pages/gov/components/PollVoters';
 import { usePollVoteDialog } from 'pages/gov/components/usePollVoteDialog';
 import { extractPollDetail } from 'pages/gov/logics/extractPollDetail';
+import { isLinkHttp } from 'pages/gov/logics/isLinkHttp';
 import { useCanIVote } from 'pages/gov/queries/canIVote';
 import { usePoll } from 'pages/gov/queries/poll';
 import { useTotalStaked } from 'pages/gov/queries/totalStaked';
@@ -150,7 +151,7 @@ function PollDetailBase({ className, match }: PollDetailProps) {
           <article>
             <h4>Link</h4>
             <p>
-              {pollDetail.poll.link ? (
+              {isLinkHttp(pollDetail.poll.link) ? (
                 <a href={pollDetail.poll.link} target="_blank" rel="noreferrer">
                   {pollDetail.poll.link}
                 </a>


### PR DESCRIPTION
Already we only allow http and https.

<https://github.com/Anchor-Protocol/anchor-web-app/blob/master/app/src/pages/gov/logics/validateLinkAddress.ts>

But, it can write dangerously links (e.g. `data:...`) by other ways (anchorcli or anchor.js).

I think we have to check from contract that the link is http or https.