### PR TITLE
feat(notation): avoid number below 0.001

### DIFF
--- a/packages/src/@anchor-protocol/notation/currency.ts
+++ b/packages/src/@anchor-protocol/notation/currency.ts
@@ -117,5 +117,6 @@ export function demicrofy<
   : C extends uToken
   ? Token<Big>
   : never {
-  return big(amount).div(MICRO) as any;
+  const value = big(amount).div(MICRO);
+  return (value < big(0.001) ? big(0) : value) as any;
 }


### PR DESCRIPTION
Hey there! 👋 

Making this change will avoid having `< 0.001` displayed.

<img width="982" alt="CleanShot 2021-05-24 at 21 35 16@2x" src="https://user-images.githubusercontent.com/2793951/119398509-f2a7b600-bcd7-11eb-9f94-db5f86a569a6.png">
