### PR TITLE
Added Estimated APR to Overview.

### DIFF
--- a/app/src/pages/borrow/components/EstimatedAPR.tsx
+++ b/app/src/pages/borrow/components/EstimatedAPR.tsx
@@ -1,0 +1,135 @@
+import {
+  AnimateNumber,
+  demicrofy,
+  formatUSTWithPostfixUnits,
+} from '@anchor-protocol/notation';
+import { Rate, UST, uUST } from '@anchor-protocol/types';
+import { IconSpan } from '@terra-dev/neumorphism-ui/components/IconSpan';
+import { InfoTooltip } from '@terra-dev/neumorphism-ui/components/InfoTooltip';
+import { Tab } from '@terra-dev/neumorphism-ui/components/Tab';
+import big, { Big } from 'big.js';
+import { useMemo, useState } from 'react';
+import { apr as _apr } from 'pages/borrow/logics/apr';
+
+import { useAnchorWebapp, useBorrowAPYQuery, useBorrowBorrowerQuery, useBorrowMarketQuery } from '@anchor-protocol/webapp-provider';
+
+export interface EstimatedAPRProps {
+  className?: string;
+}
+
+export type Period = 'total' | 'year' | 'month' | 'week' | 'day' | 'epoch';
+
+interface Item {
+  label: string;
+  value: Period;
+}
+
+const tabItems: Item[] = [
+  {
+    label: 'WEEK',
+    value: 'week',
+  },
+  {
+    label: 'DAY',
+    value: 'day',
+  }, {
+    label: 'EPOCH',
+    value: 'epoch',
+  },
+];
+
+export function EstimatedAPR({ className }: EstimatedAPRProps) {
+
+  const {
+    constants: { epochsPerYear, blocksPerYear },
+  } = useAnchorWebapp();
+
+  const { data: { borrowerDistributionAPYs } = {} } = useBorrowAPYQuery();
+  
+  const {
+    data: { marketBorrowerInfo } = {},
+  } = useBorrowBorrowerQuery();
+  
+  const {
+    data: { borrowRate } = {},
+  } = useBorrowMarketQuery();
+  
+  const apr = useMemo(() => _apr(borrowRate, blocksPerYear), [
+    blocksPerYear,
+    borrowRate,
+  ]);
+ 
+  const aprNet = useMemo(
+    () => 
+      borrowerDistributionAPYs && borrowerDistributionAPYs.length > 0
+      ? (big(borrowerDistributionAPYs[0].DistributionAPY).minus(
+          apr,
+        ) as Rate<Big>)
+      : (0 as Rate<number>),
+    [borrowerDistributionAPYs, apr]
+  );
+
+  // ---------------------------------------------
+  // states
+  // ---------------------------------------------
+  const [tab, setTab] = useState<Item>(() => tabItems[1]);
+
+  // ---------------------------------------------
+  // logics
+  // ---------------------------------------------
+  const estimatedReturn = useMemo(() => {
+    if (!marketBorrowerInfo) {
+      return undefined;
+    }
+
+    return (big(marketBorrowerInfo.loan_amount).mul(aprNet)
+      .div(
+        tab.value === 'week'
+          ? 52
+          : tab.value === 'day'
+            ? 365
+            : tab.value === 'epoch'
+              ? epochsPerYear
+              : 365
+      )) as uUST<Big>;
+  }, [
+    marketBorrowerInfo,
+    aprNet,
+    tab.value,
+    epochsPerYear
+  ]);
+
+  // ---------------------------------------------
+  // presentation
+  // ---------------------------------------------
+  return (
+
+    <div className="apy">
+      <h3>
+        <IconSpan>
+          Estimated Interest at stable APR{' '}
+          <InfoTooltip>
+            Estimated interest (not compounded) for the selected time period. Highly unlikely to be accurate above day period.
+              </InfoTooltip>
+        </IconSpan>
+      </h3>
+      <div className="value">
+        $
+        <AnimateNumber format={formatUSTWithPostfixUnits}>
+          {estimatedReturn ? demicrofy(estimatedReturn) : (0 as UST<number>)}
+        </AnimateNumber>
+      </div>
+      <Tab
+        className="tab"
+        items={tabItems}
+        selectedItem={tab ?? tabItems[0]}
+        onChange={setTab}
+        labelFunction={({ label }) => label}
+        keyFunction={({ value }) => value}
+        height={46}
+        borderRadius={30}
+        fontSize={12}
+      />
+    </div>
+  );
+}

--- a/app/src/pages/borrow/components/Overview.tsx
+++ b/app/src/pages/borrow/components/Overview.tsx
@@ -31,6 +31,7 @@ import { apr as _apr } from '../logics/apr';
 import { borrowed as _borrowed } from '../logics/borrowed';
 import { collaterals as _collaterals } from '../logics/collaterals';
 import { BorrowLimitGraph } from './BorrowLimitGraph';
+import { EstimatedAPR } from './EstimatedAPR';
 
 export interface OverviewProps {
   className?: string;
@@ -190,6 +191,7 @@ function OverviewBase({ className }: OverviewProps) {
             </Circles>
           </div>
         </div>
+      <EstimatedAPR />
       </article>
 
       {currentLtv && bLunaSafeLtv && bLunaMaxLtv && marketBorrowerInfo && (

--- a/base/src/base/AppProviders.tsx
+++ b/base/src/base/AppProviders.tsx
@@ -150,12 +150,14 @@ function Providers({ children }: { children: ReactNode }) {
             gasFee: 1000000 as uUST<number>,
             fixedGas: 250000 as uUST<number>,
             blocksPerYear: 4906443,
+            epochsPerYear: 2920,
             gasAdjustment: 1.6 as Rate<number>,
           }
         : {
             gasFee: 6000000 as uUST<number>,
             fixedGas: 3500000 as uUST<number>,
             blocksPerYear: 4906443,
+            epochsPerYear: 2920,
             gasAdjustment: 1.4 as Rate<number>,
           },
     [isMainnet],

--- a/base/src/base/contexts/contants.tsx
+++ b/base/src/base/contexts/contants.tsx
@@ -13,6 +13,7 @@ export interface Constants {
   fixedGas: uUST<number>;
   gasAdjustment: Rate<number>;
   blocksPerYear: number;
+  epochsPerYear: number;
 }
 
 // @ts-ignore

--- a/packages/src/@anchor-protocol/webapp-fns/env.ts
+++ b/packages/src/@anchor-protocol/webapp-fns/env.ts
@@ -73,12 +73,14 @@ export const DEFAULT_ANCHOR_TX_CONSTANTS: Record<string, AnchorContants> = {
     fixedGas: 250000 as uUST<number>,
     blocksPerYear: 4906443,
     gasAdjustment: 1.6 as Rate<number>,
+    epochsPerYear: 2096,
   },
   testnet: {
     gasFee: 6000000 as uUST<number>,
     fixedGas: 3500000 as uUST<number>,
     blocksPerYear: 4906443,
     gasAdjustment: 1.4 as Rate<number>,
+    epochsPerYear: 2096,
   },
 };
 

--- a/packages/src/@anchor-protocol/webapp-fns/types.ts
+++ b/packages/src/@anchor-protocol/webapp-fns/types.ts
@@ -14,6 +14,7 @@ export interface AnchorContants {
   fixedGas: uUST<number>;
   blocksPerYear: number;
   gasAdjustment: Rate<number>;
+  epochsPerYear: number;
 }
 
 /**


### PR DESCRIPTION
Made this for fun but maybe someone else wants it too? 

**What**
* Added a new block to borrow page that shows you an estimation of the return of your APR in the style of the earn page.

![Animation](https://user-images.githubusercontent.com/10973885/119714520-4266b880-be63-11eb-8d03-2ae81d847558.gif)

**Why?**
I think it's handy to be able to see what the current APR does for me in the short run.

Love the project!