### PR TITLE
Feat: add estimated bLuna liquidation price in borrow and repay dialog

### DIFF
--- a/app/src/pages/borrow/components/useBorrowDialog.tsx
+++ b/app/src/pages/borrow/components/useBorrowDialog.tsx
@@ -44,6 +44,7 @@ import { borrowReceiveAmount } from '../logics/borrowReceiveAmount';
 import { borrowSafeMax } from '../logics/borrowSafeMax';
 import { borrowTxFee } from '../logics/borrowTxFee';
 import { currentLtv as _currentLtv } from '../logics/currentLtv';
+import { estimateLiquidationPrice } from '../logics/estimateLiquidationPrice';
 import { ltvToBorrowAmount } from '../logics/ltvToBorrowAmount';
 import { validateBorrowAmount } from '../logics/validateBorrowAmount';
 import { LTVGraph } from './LTVGraph';
@@ -132,6 +133,11 @@ function ComponentBase({
   const nextLtv = useMemo(
     () => borrowNextLtv(borrowAmount, currentLtv, amountToLtv),
     [amountToLtv, borrowAmount, currentLtv],
+  );
+
+  const estimatedLiqPrice = useMemo(
+    () => estimateLiquidationPrice(nextLtv, bLunaMaxLtv, oraclePrice),
+    [nextLtv, bLunaMaxLtv, oraclePrice],
   );
 
   const userMaxLtv = useMemo(() => {
@@ -336,6 +342,13 @@ function ComponentBase({
             onChange={onLtvChange}
           />
         </figure>
+
+        {nextLtv?.gt(currentLtv || 0) && (
+          <sup>
+            Estimated bLuna Liquidation Price : {formatUST(estimatedLiqPrice)}{' '}
+            UST
+          </sup>
+        )}
 
         {nextLtv?.gt(bLunaSafeLtv) && (
           <MessageBox

--- a/app/src/pages/borrow/components/useBorrowDialog.tsx
+++ b/app/src/pages/borrow/components/useBorrowDialog.tsx
@@ -345,7 +345,7 @@ function ComponentBase({
 
         {nextLtv?.gt(currentLtv || 0) && (
           <sup>
-            Estimated bLuna Liquidation Price : {formatUST(estimatedLiqPrice)}{' '}
+            Estimated bLuna Liquidation Price: {formatUST(estimatedLiqPrice)}{' '}
             UST
           </sup>
         )}

--- a/app/src/pages/borrow/components/useRepayDialog.tsx
+++ b/app/src/pages/borrow/components/useRepayDialog.tsx
@@ -37,6 +37,7 @@ import React, { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { apr as _apr } from '../logics/apr';
 import { currentLtv as _currentLtv } from '../logics/currentLtv';
+import { estimateLiquidationPrice } from '../logics/estimateLiquidationPrice';
 import { ltvToRepayAmount } from '../logics/ltvToRepayAmount';
 import { repayAmountToLtv } from '../logics/repayAmountToLtv';
 import { repayNextLtv } from '../logics/repayNextLtv';
@@ -131,6 +132,11 @@ function ComponentBase({
   const nextLtv = useMemo(
     () => repayNextLtv(repayAmount, currentLtv, amountToLtv),
     [amountToLtv, currentLtv, repayAmount],
+  );
+
+  const estimatedLiqPrice = useMemo(
+    () => estimateLiquidationPrice(nextLtv, bLunaMaxLtv, oraclePrice),
+    [nextLtv, bLunaMaxLtv, oraclePrice],
   );
 
   const apr = useMemo(() => _apr(borrowRate, blocksPerYear), [
@@ -314,6 +320,13 @@ function ComponentBase({
             onChange={onLtvChange}
           />
         </figure>
+
+        {nextLtv?.lt(currentLtv || 0) && (
+          <sup>
+            Estimated bLuna Liquidation Price : {formatUST(estimatedLiqPrice)}{' '}
+            UST
+          </sup>
+        )}
 
         {totalOutstandingLoan && txFee && sendAmount && (
           <TxFeeList className="receipt">

--- a/app/src/pages/borrow/components/useRepayDialog.tsx
+++ b/app/src/pages/borrow/components/useRepayDialog.tsx
@@ -323,7 +323,7 @@ function ComponentBase({
 
         {nextLtv?.lt(currentLtv || 0) && (
           <sup>
-            Estimated bLuna Liquidation Price : {formatUST(estimatedLiqPrice)}{' '}
+            Estimated bLuna Liquidation Price: {formatUST(estimatedLiqPrice)}{' '}
             UST
           </sup>
         )}

--- a/app/src/pages/borrow/logics/estimateLiquidationPrice.ts
+++ b/app/src/pages/borrow/logics/estimateLiquidationPrice.ts
@@ -1,0 +1,16 @@
+import type { Rate, UST } from '@anchor-protocol/types';
+import { moneyMarket } from '@anchor-protocol/types';
+import big, { Big, BigSource } from 'big.js';
+
+export function estimateLiquidationPrice(
+  nextLtv: Rate<Big> | undefined,
+  bLunaMaxLtv: Rate<BigSource>,
+  oracle: moneyMarket.oracle.PriceResponse,
+): UST<BigSource> {
+  // formula:
+  // oracle price * (nextLtv / maxLtv)
+  if (nextLtv) {
+    return big(oracle.rate).mul(big(nextLtv).div(big(bLunaMaxLtv))) as UST<Big>;
+  }
+  return oracle.rate;
+}

--- a/app/src/pages/borrow/logics/estimateLiquidationPrice.ts
+++ b/app/src/pages/borrow/logics/estimateLiquidationPrice.ts
@@ -7,8 +7,7 @@ export function estimateLiquidationPrice(
   bLunaMaxLtv: Rate<BigSource>,
   oracle: moneyMarket.oracle.PriceResponse,
 ): UST<BigSource> {
-  // formula:
-  // oracle price * (nextLtv / maxLtv)
+  // formula: oracle price * (nextLtv / maxLtv)
   if (nextLtv) {
     return big(oracle.rate).mul(big(nextLtv).div(big(bLunaMaxLtv))) as UST<Big>;
   }


### PR DESCRIPTION
**Description**:
Add estimated bLuna liquidation price in borrow and repay dialog

**Changes**:

- add `estimateLiquidationPrice` using the formula bLuna oracle price * (newLtv / maxLtv)
- add estimated bLuna liquidation price when borrow or repay amount changed in the borrow or repay dialog

**Result**:
_borrowDialog_
<img width="637" alt="borrowDialog" src="https://user-images.githubusercontent.com/8136256/120079873-933b1300-c0e8-11eb-8d5b-743e031aff1a.png">

_repayDialog_
<img width="632" alt="repayDialog" src="https://user-images.githubusercontent.com/8136256/120079890-a51cb600-c0e8-11eb-8378-ec397bc1e4bd.png">

