### PR TITLE
Dashboard Icon: Open in new tab

### DIFF
--- a/app/src/components/Header/DesktopHeader.tsx
+++ b/app/src/components/Header/DesktopHeader.tsx
@@ -33,11 +33,11 @@ function DesktopHeaderBase({ className }: DesktopHeaderProps) {
   return (
     <header className={className}>
       <Tooltip
-        title="Go to Dashboard"
+        title="Open the Dashboard"
         placement="right"
         classes={tooltipClasses}
       >
-        <a className="logo" href="https://anchorprotocol.com/dashboard">
+        <a className="logo" href="https://anchorprotocol.com/dashboard" target="_blank">
           <img src={logoUrl} alt="logo" />
         </a>
       </Tooltip>

--- a/app/src/components/Header/DesktopHeader.tsx
+++ b/app/src/components/Header/DesktopHeader.tsx
@@ -37,7 +37,7 @@ function DesktopHeaderBase({ className }: DesktopHeaderProps) {
         placement="right"
         classes={tooltipClasses}
       >
-        <a className="logo" href="https://anchorprotocol.com/dashboard" target="_blank">
+        <a className="logo" href="https://anchorprotocol.com/dashboard" target="_blank" rel="noreferrer">
           <img src={logoUrl} alt="logo" />
         </a>
       </Tooltip>

--- a/app/src/components/Header/MobileHeader.tsx
+++ b/app/src/components/Header/MobileHeader.tsx
@@ -120,7 +120,7 @@ function MobileHeaderBase({ className }: MobileHeaderProps) {
           </nav>
         )}
         <section className="header">
-          <a className="logo" href="https://anchorprotocol.com/dashboard" target="_blank">
+          <a className="logo" href="https://anchorprotocol.com/dashboard" target="_blank" rel="noreferrer">
             <img src={logoUrl} alt="logo" />
           </a>
 

--- a/app/src/components/Header/MobileHeader.tsx
+++ b/app/src/components/Header/MobileHeader.tsx
@@ -120,7 +120,7 @@ function MobileHeaderBase({ className }: MobileHeaderProps) {
           </nav>
         )}
         <section className="header">
-          <a className="logo" href="https://anchorprotocol.com/dashboard">
+          <a className="logo" href="https://anchorprotocol.com/dashboard" target="_blank">
             <img src={logoUrl} alt="logo" />
           </a>
 


### PR DESCRIPTION
When in the Dashboard and we click on "WebApp", a new tab is opened, however when we click the Dashboard icon in the header, it opens inside the same tab.
To keep it consistent, I made it open in a new tab as well.