### PR TITLE
Update Discord invite URL

### DIFF
--- a/app/src/components/TxResultRenderer/renderTxFailedReason.tsx
+++ b/app/src/components/TxResultRenderer/renderTxFailedReason.tsx
@@ -16,7 +16,7 @@ const channels = (
     <li>
       Discord :{' '}
       <a href="https://discord.gg/9aUYgpKZ9c" target="_blank" rel="noreferrer">
-        https://discord.gg/9aUYgpKZ9c
+        https://discord.gg/3gaVztyuT2
       </a>
     </li>
     <li>


### PR DESCRIPTION
So the person goes straight to the #error-support channel (if they are already on Anchor's Discord... otherwise they'll still have to solve the captcha challenge first).