### PR TITLE
[WIP] feat: clearer theme change button

### DIFF
--- a/app/src/components/Footer/index.tsx
+++ b/app/src/components/Footer/index.tsx
@@ -86,7 +86,7 @@ function FooterBase({ className, style }: FooterProps) {
         <IconButton
           onClick={() => updateTheme(themeColor === 'light' ? 'dark' : 'light')}
         >
-          {themeColor === 'light' ? <Brightness5 /> : <Brightness3 />}
+          {themeColor === 'light' ? <Brightness3 /> : <Brightness5 />}
         </IconButton>
       </div>
     </footer>

--- a/app/src/components/Footer/index.tsx
+++ b/app/src/components/Footer/index.tsx
@@ -49,6 +49,13 @@ function FooterBase({ className, style }: FooterProps) {
         <Link to="/terms" style={{ marginLeft: 28 }}>
           Terms
         </Link>
+
+        <IconButton
+          style={{ marginLeft: 28 }}
+          onClick={() => updateTheme(themeColor === 'light' ? 'dark' : 'light')}
+        >
+          {themeColor === 'light' ? <Brightness3 /> : <Brightness5 />}
+        </IconButton>
       </div>
       <div>
         <IconButton
@@ -82,11 +89,6 @@ function FooterBase({ className, style }: FooterProps) {
           rel="noreferrer"
         >
           <GitHub />
-        </IconButton>
-        <IconButton
-          onClick={() => updateTheme(themeColor === 'light' ? 'dark' : 'light')}
-        >
-          {themeColor === 'light' ? <Brightness3 /> : <Brightness5 />}
         </IconButton>
       </div>
     </footer>

--- a/app/src/components/Header/DesktopHeader.tsx
+++ b/app/src/components/Header/DesktopHeader.tsx
@@ -42,17 +42,16 @@ function DesktopHeaderBase({ className }: DesktopHeaderProps) {
         <WalletSelector />
       </section>
 
-      <div>
-        <IconButton
-          onClick={() => updateTheme(themeColor === 'light' ? 'dark' : 'light')}
-        >
-          {themeColor === 'light' ? (
-            <Brightness2 style={{ fill: 'white' }} />
-          ) : (
-            <Brightness5 style={{ fill: 'white' }} />
-          )}
-        </IconButton>
-      </div>
+      <IconButton
+        style={{ top: '3px' }}
+        onClick={() => updateTheme(themeColor === 'light' ? 'dark' : 'light')}
+      >
+        {themeColor === 'light' ? (
+          <Brightness2 style={{ fill: 'white' }} />
+        ) : (
+          <Brightness5 style={{ fill: 'white' }} />
+        )}
+      </IconButton>
 
       <GlobalStyle />
     </header>

--- a/app/src/components/Header/DesktopHeader.tsx
+++ b/app/src/components/Header/DesktopHeader.tsx
@@ -6,12 +6,17 @@ import styled, { createGlobalStyle } from 'styled-components';
 import logoUrl from './assets/Logo.svg';
 import { DesktopNotification } from './desktop/DesktopNotification';
 import { WalletSelector } from './desktop/WalletSelector';
+import { IconButton } from '@material-ui/core';
+import { Brightness2, Brightness5 } from '@material-ui/icons';
+import { useTheme } from 'contexts/theme';
 
 export interface DesktopHeaderProps {
   className?: string;
 }
 
 function DesktopHeaderBase({ className }: DesktopHeaderProps) {
+  const { themeColor, updateTheme } = useTheme();
+
   return (
     <header className={className}>
       <a
@@ -36,6 +41,18 @@ function DesktopHeaderBase({ className }: DesktopHeaderProps) {
       <section className="wallet">
         <WalletSelector />
       </section>
+
+      <div>
+        <IconButton
+          onClick={() => updateTheme(themeColor === 'light' ? 'dark' : 'light')}
+        >
+          {themeColor === 'light' ? (
+            <Brightness2 style={{ fill: 'white' }} />
+          ) : (
+            <Brightness5 style={{ fill: 'white' }} />
+          )}
+        </IconButton>
+      </div>
 
       <GlobalStyle />
     </header>


### PR DESCRIPTION
I was playing around with the Anchor web app and was searching for the dark theme switch and found it in the footer. Most other switches have the icons the other way around and placed in the header (See [coingecko](https://www.coingecko.com/nl) for example). Changed it around to this:

**Header**
![Screenshot from 2022-01-05 22-00-07](https://user-images.githubusercontent.com/30845815/148289827-fb4dacfb-d1d8-4ed9-a62e-ca6cab9d48b7.png)

**Footer**
![Screenshot from 2022-01-05 22-00-27](https://user-images.githubusercontent.com/30845815/148289934-cdb26318-deea-411a-ba71-82d4580cc256.png)

This way you have a switch when you are at the top of the page and also a switch on the bottom of the page. Not really sure if you agree with this, so I didn't fully clean up the code yet. 

Curious to hear if you agree with this and I'm definitely open to any feedback! 😄 
