### PR TITLE
Display real APY

### DIFF
--- a/app/src/@anchor-protocol/app-fns/logics/earn/computeCurrentAPY.ts
+++ b/app/src/@anchor-protocol/app-fns/logics/earn/computeCurrentAPY.ts
@@ -6,7 +6,7 @@ export function computeCurrentAPY(
   overseerEpochState: moneyMarket.overseer.EpochStateResponse | undefined,
   blocksPerYear: number,
 ): Rate<Big> {
-  return big(overseerEpochState?.deposit_rate ?? '0').mul(
-    blocksPerYear,
-  ) as Rate<Big>;
+  const blockApr = parseFloat(overseerEpochState?.deposit_rate ?? '0') + 1;
+  // can't use .pow() since blocksPerYear is bigger than 1e6
+  return big(Math.pow(blockApr, blocksPerYear)).sub(1) as Rate<Big>;
 }

--- a/app/src/pages/earn/components/ExpectedInterestSection.tsx
+++ b/app/src/pages/earn/components/ExpectedInterestSection.tsx
@@ -64,21 +64,26 @@ export function ExpectedInterestSection({
     }
 
     const ustBalance = big(uaUST).mul(moneyMarketEpochState.exchange_rate);
-    const annualizedInterestRate = big(overseerEpochState.deposit_rate).mul(
-      constants.blocksPerYear,
-    );
 
-    return ustBalance
-      .mul(annualizedInterestRate)
-      .div(
-        tab.value === 'month'
-          ? 12
-          : tab.value === 'week'
-          ? 52
-          : tab.value === 'day'
-          ? 365
-          : 1,
-      ) as u<UST<Big>>;
+    const blockApr = parseFloat(overseerEpochState.deposit_rate) + 1;
+    const dayInterestRate = big(Math.pow(blockApr, constants.blocksPerYear))
+      .sub(1)
+      .div(365);
+
+    return ustBalance.mul(
+      dayInterestRate
+        .add(1)
+        .pow(
+          tab.value === 'month'
+            ? 30
+            : tab.value === 'week'
+            ? 7
+            : tab.value === 'day'
+            ? 1
+            : 365,
+        )
+        .sub(1),
+    ) as u<UST<Big>>;
   }, [
     constants.blocksPerYear,
     moneyMarketEpochState,

--- a/app/src/pages/earn/components/InterestSection.tsx
+++ b/app/src/pages/earn/components/InterestSection.tsx
@@ -48,8 +48,8 @@ export function InterestSection({ className }: InterestSectionProps) {
     const history = apyHistory
       ?.map(({ Timestamp, DepositRate }) => ({
         date: new Date(Timestamp * 1000),
-        value: (parseFloat(DepositRate) *
-          constants.blocksPerYear) as Rate<number>,
+        value: (Math.pow(parseFloat(DepositRate) + 1, constants.blocksPerYear) -
+          1) as Rate<number>,
       }))
       .reverse();
 
@@ -58,9 +58,10 @@ export function InterestSection({ className }: InterestSectionProps) {
           ...history,
           {
             date: new Date(),
-            value: big(overseerEpochState.deposit_rate)
-              .mul(constants.blocksPerYear)
-              .toNumber() as Rate<number>,
+            value: (Math.pow(
+              big(overseerEpochState.deposit_rate).add(1).toNumber(),
+              constants.blocksPerYear,
+            ) - 1) as Rate<number>,
           },
         ]
       : undefined;


### PR DESCRIPTION
Anchor's web app currently shows APR instead of APY, I made some changes to show the correct one with compounding every block.

Problem pointed out by ColinTCrypto:
https://twitter.com/ColinTCrypto/status/1484896937849589764