### PR TITLE
fix(Swap.tsx): removed display: none from styled component const since burn and gett inputs are not showing

### DIFF
--- a/app/src/pages/basset/components/BLunaBurn/Swap.tsx
+++ b/app/src/pages/basset/components/BLunaBurn/Swap.tsx
@@ -482,7 +482,6 @@ export function Component({
 const StyledComponent = styled(Component)`
   .burn,
   .gett {
-    display: none;
     img {
       font-size: 12px;
     }


### PR DESCRIPTION

# Description

When we try to instant burn bLuna to Luna we are missing the `SelectAndTextInputContainer` components from the DOM
Thus i have found out that we have a `display: none` class permitting it to be shown inside the DOM.
Removing it from the css it appears that it is working correctly.


## Type of change

-   [x] Non Breaking change


# Checklist:

-   [x] Removed `display: none` from `Swap.tsx` component

# Notes (specific implementation details)

I have found that when i click instant burn here https://app.anchorprotocol.com/basset/bluna/burn i didn't get inputs shown inside the template.

# Screenshots (optional)

Before:
![photo_2022-01-29_11-31-34](https://user-images.githubusercontent.com/19847933/151656292-1fbf257e-a20d-4b18-8ae1-65ff940a88eb.jpg)

After:
![image](https://user-images.githubusercontent.com/19847933/151656354-021362cd-b77f-4707-b068-d02fff92a2c3.png)
