### PR TITLE
fix: improve readability on gov proposal description by removing word breaking on new line

### DIFF
--- a/app/src/pages/gov/components/DescriptionGrid.tsx
+++ b/app/src/pages/gov/components/DescriptionGrid.tsx
@@ -28,8 +28,8 @@ const itemStyle = css`
       font-size: 14px;
       line-height: 1.5;
       max-width: 90%;
-
-      word-break: break-all;
+      word-break: normal;
+      text-align: justify;
       white-space: break-spaces;
     }
   }


### PR DESCRIPTION
**Description**:
in gov proposal description, word are broken when entering new line, which has reduce readability, this fix is to remove word break on new line to improve readability

**Result**:
_Before Fix:_
![before_word_break_fix](https://user-images.githubusercontent.com/8136256/153221556-664f4ef7-0d04-47a2-a340-5651c928c9a8.png)

_After Fix:_
![after_word_break_fix](https://user-images.githubusercontent.com/8136256/153221609-6c146aa6-7b3b-428a-ad70-3a8f6ce7aee0.png)

