### PR TITLE
Claim rewards flow improvements

### DIFF
--- a/app/src/@anchor-protocol/app-fns/tx/basset/claim.ts
+++ b/app/src/@anchor-protocol/app-fns/tx/basset/claim.ts
@@ -1,6 +1,7 @@
 import { formatUSTWithPostfixUnits } from '@anchor-protocol/notation';
 import { Gas, HumanAddr, Rate, u, UST } from '@anchor-protocol/types';
 import {
+  CW20TokenDisplayInfo,
   pickAttributeValueByKey,
   pickEvent,
   pickRawLogs,
@@ -25,12 +26,18 @@ import {
   MsgExecuteContract,
 } from '@terra-money/terra.js';
 import { NetworkInfo, TxResult } from '@terra-money/use-wallet';
+import { RewardBreakdown } from 'pages/basset/hooks/useRewardsBreakdown';
 import { Observable } from 'rxjs';
+
+type RewardLogWithDisplay = {
+  rewards: string;
+  contract: string;
+  tokenDisplay: CW20TokenDisplayInfo;
+};
 
 export function bAssetClaimTx($: {
   walletAddr: HumanAddr;
-  rewardAddrs: HumanAddr[];
-
+  rewardBreakdowns: RewardBreakdown[];
   gasFee: Gas;
   gasAdjustment: Rate<number>;
   fixedGas: u<UST>;
@@ -44,12 +51,16 @@ export function bAssetClaimTx($: {
 
   return pipe(
     _createTxOptions({
-      msgs: $.rewardAddrs.map((rewardAddr) => {
-        return new MsgExecuteContract($.walletAddr, rewardAddr, {
-          claim_rewards: {
-            recipient: undefined,
+      msgs: $.rewardBreakdowns.map((rewardBreakdown) => {
+        return new MsgExecuteContract(
+          $.walletAddr,
+          rewardBreakdown.rewardAddr,
+          {
+            claim_rewards: {
+              recipient: undefined,
+            },
           },
-        });
+        );
       }),
       fee: new Fee($.gasFee, floor($.fixedGas) + 'uusd'),
       gasAdjustment: $.gasAdjustment,
@@ -59,38 +70,55 @@ export function bAssetClaimTx($: {
     ({ value: txInfo }) => {
       const rawLogs = pickRawLogs(txInfo);
 
-      // for now just aggregate the total rewards, but we can split
-      // these in the receipts if we can map the contract addresses
-      const total = rawLogs.reduce((previous, current) => {
-        const wasm = pickEvent(current, 'wasm');
+      const rewardBreakdownByRewardContract = $.rewardBreakdowns.reduce(
+        (acc, curr) => ({ ...acc, [curr.rewardAddr]: curr }),
+        {} as { [k: string]: RewardBreakdown },
+      );
+
+      const rewardLogsWithDisplay = rawLogs.reduce((acc, curr) => {
+        const wasm = pickEvent(curr, 'wasm');
         if (wasm) {
           const rewards = pickAttributeValueByKey<string>(wasm, 'rewards');
-          if (rewards) {
-            return previous.add(rewards);
+          const contract = pickAttributeValueByKey<string>(
+            wasm,
+            'contract_address',
+          );
+
+          if (rewards && contract) {
+            return [
+              ...acc,
+              {
+                rewards,
+                contract,
+                tokenDisplay:
+                  rewardBreakdownByRewardContract[contract].tokenDisplay,
+              },
+            ];
           }
         }
-        return previous;
-      }, new Dec(0));
 
-      // const rawLog = pickRawLog(txInfo, 0);
+        return acc;
+      }, [] as RewardLogWithDisplay[]);
 
-      // if (!rawLog) {
-      //   return helper.failedToFindRawLog();
-      // }
-
-      // const wasm = pickEvent(rawLog, 'wasm');
-
-      // if (!wasm) {
-      //   return helper.failedToFindEvents('wasm');
-      // }
+      const total = rewardLogsWithDisplay.reduce(
+        (acc, curr) => acc.add(curr.rewards),
+        new Dec(0),
+      );
 
       try {
         return {
           value: null,
           phase: TxStreamPhase.SUCCEED,
           receipts: [
+            ...rewardLogsWithDisplay.map((rewardLog) => ({
+              name: `${rewardLog.tokenDisplay.symbol} Reward`,
+              value:
+                formatUSTWithPostfixUnits(
+                  demicrofy(rewardLog.rewards as u<UST>),
+                ) + ' UST',
+            })),
             total && {
-              name: 'Claimed Rewards',
+              name: 'Total Rewards',
               value:
                 formatUSTWithPostfixUnits(
                   demicrofy(total.toString() as u<UST>),

--- a/app/src/@anchor-protocol/app-provider/tx/basset/claim.ts
+++ b/app/src/@anchor-protocol/app-provider/tx/basset/claim.ts
@@ -1,14 +1,14 @@
 import { bAssetClaimTx } from '@anchor-protocol/app-fns';
 import { useFixedFee, useRefetchQueries } from '@libs/app-provider';
-import { HumanAddr } from '@libs/types';
 import { useStream } from '@rx-stream/react';
 import { useConnectedWallet } from '@terra-money/wallet-provider';
+import { RewardBreakdown } from 'pages/basset/hooks/useRewardsBreakdown';
 import { useCallback } from 'react';
 import { useAnchorWebapp } from '../../contexts/context';
 import { ANCHOR_TX_KEY } from '../../env';
 
 export interface BAssetClaimTxParams {
-  rewardAddrs: HumanAddr[];
+  rewardBreakdowns: RewardBreakdown[];
   onTxSucceed?: () => void;
 }
 
@@ -22,7 +22,7 @@ export function useBAssetClaimTx() {
   const refetchQueries = useRefetchQueries();
 
   const stream = useCallback(
-    ({ onTxSucceed, rewardAddrs }: BAssetClaimTxParams) => {
+    ({ onTxSucceed, rewardBreakdowns }: BAssetClaimTxParams) => {
       if (!connectedWallet || !connectedWallet.availablePost) {
         throw new Error('Can not post!');
       }
@@ -30,7 +30,7 @@ export function useBAssetClaimTx() {
       return bAssetClaimTx({
         // fabricatebAssetClaimRewards
         walletAddr: connectedWallet.walletAddress,
-        rewardAddrs,
+        rewardBreakdowns,
         // post
         network: connectedWallet.network,
         post: connectedWallet.post,

--- a/app/src/pages/basset/claim.tsx
+++ b/app/src/pages/basset/claim.tsx
@@ -1,20 +1,14 @@
 import { validateTxFee } from '@anchor-protocol/app-fns';
-import {
-  useAnchorBank,
-  useAnchorWebapp,
-  useBAssetClaimableRewardsTotalQuery,
-  useBAssetClaimTx,
-  useBLunaClaimableRewards,
-} from '@anchor-protocol/app-provider';
+import { useAnchorBank, useBAssetClaimTx } from '@anchor-protocol/app-provider';
 import { formatUST } from '@anchor-protocol/notation';
 import { useFixedFee } from '@libs/app-provider';
 import { demicrofy } from '@libs/formatter';
 import { ActionButton } from '@libs/neumorphism-ui/components/ActionButton';
 import { Section } from '@libs/neumorphism-ui/components/Section';
-import { HumanAddr, u, UST } from '@libs/types';
+import { u, UST } from '@libs/types';
 import { StreamStatus } from '@rx-stream/react';
 import { useConnectedWallet } from '@terra-money/wallet-provider';
-import big, { Big } from 'big.js';
+import { Big } from 'big.js';
 import { CenteredLayout } from 'components/layouts/CenteredLayout';
 import { MessageBox } from 'components/MessageBox';
 import { Sub } from 'components/Sub';
@@ -22,9 +16,9 @@ import { TxResultRenderer } from 'components/tx/TxResultRenderer';
 import { TxFeeList, TxFeeListItem } from 'components/TxFeeList';
 import { ViewAddressWarning } from 'components/ViewAddressWarning';
 import { fixHMR } from 'fix-hmr';
-import { claimableRewards as _claimableRewards } from 'pages/basset/logics/claimableRewards';
 import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
+import { useClaimableRewardsBreakdown } from './hooks/useRewardsBreakdown';
 
 export interface BAssetClaimProps {
   className?: string;
@@ -40,18 +34,12 @@ function Component({ className }: BAssetClaimProps) {
 
   const [claim, claimResult] = useBAssetClaimTx();
 
-  const { contractAddress } = useAnchorWebapp();
-
   // ---------------------------------------------
   // queries
   // ---------------------------------------------
   const { tokenBalances } = useAnchorBank();
 
-  const { data: { claimableReward, rewardState } = {} } =
-    useBLunaClaimableRewards();
-
-  const { data: { total, rewards } = {} } =
-    useBAssetClaimableRewardsTotalQuery();
+  const { totalRewardsUST, rewardBreakdowns } = useClaimableRewardsBreakdown();
 
   //const {} = useAnchorWebapp()
 
@@ -63,60 +51,27 @@ function Component({ className }: BAssetClaimProps) {
     [connectedWallet, tokenBalances.uUST, fixedFee],
   );
 
-  const claimableRewards = useMemo(
-    () =>
-      _claimableRewards(claimableReward, rewardState).plus(total ?? '0') as u<
-        UST<Big>
-      >,
-    [claimableReward, rewardState, total],
-  );
-
   const estimatedAmount = useMemo(() => {
-    const amount = claimableRewards.minus(fixedFee) as u<UST<Big>>;
+    const amount = totalRewardsUST.minus(fixedFee) as u<UST<Big>>;
     return amount.gt(fixedFee) ? amount : undefined;
-  }, [claimableRewards, fixedFee]);
+  }, [totalRewardsUST, fixedFee]);
 
   // ---------------------------------------------
   // callbacks
   // ---------------------------------------------
   const proceed = useCallback(() => {
-    if (
-      !connectedWallet ||
-      !claim ||
-      !claimableReward ||
-      !rewardState ||
-      !rewards
-    ) {
+    if (!connectedWallet || !claim || !totalRewardsUST) {
       return;
     }
 
-    const balanceExistsRewardsAddrs: HumanAddr[] = [];
-
-    if (_claimableRewards(claimableReward, rewardState).gt(0)) {
-      balanceExistsRewardsAddrs.push(contractAddress.bluna.reward);
-    }
-
-    for (const [rewardAddr, reward] of rewards) {
-      if (big(reward.claimableReward.rewards).gt(0)) {
-        balanceExistsRewardsAddrs.push(rewardAddr);
-      }
-    }
-
-    if (balanceExistsRewardsAddrs.length === 0) {
+    if (rewardBreakdowns.length === 0) {
       throw new Error('There is no rewards');
     }
 
     claim({
-      rewardAddrs: balanceExistsRewardsAddrs,
+      rewardBreakdowns,
     });
-  }, [
-    claim,
-    claimableReward,
-    connectedWallet,
-    contractAddress.bluna.reward,
-    rewardState,
-    rewards,
-  ]);
+  }, [claim, totalRewardsUST, connectedWallet, rewardBreakdowns]);
 
   // ---------------------------------------------
   // presentation
@@ -151,12 +106,12 @@ function Component({ className }: BAssetClaimProps) {
       <Section>
         <h1>Claim Rewards</h1>
 
-        {!!invalidTxFee && claimableRewards.gt(0) && (
+        {!!invalidTxFee && totalRewardsUST.gt(0) && (
           <MessageBox>{invalidTxFee}</MessageBox>
         )}
 
         <div className="amount">
-          {formatUST(demicrofy(claimableRewards))} <Sub>UST</Sub>
+          {formatUST(demicrofy(totalRewardsUST))} <Sub>UST</Sub>
         </div>
 
         <TxFeeList className="receipt">

--- a/app/src/pages/basset/claim.tsx
+++ b/app/src/pages/basset/claim.tsx
@@ -17,6 +17,7 @@ import { TxFeeList, TxFeeListItem } from 'components/TxFeeList';
 import { ViewAddressWarning } from 'components/ViewAddressWarning';
 import { fixHMR } from 'fix-hmr';
 import React, { useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { useClaimableRewardsBreakdown } from './hooks/useRewardsBreakdown';
 
@@ -29,6 +30,7 @@ function Component({ className }: BAssetClaimProps) {
   // dependencies
   // ---------------------------------------------
   const connectedWallet = useConnectedWallet();
+  const history = useHistory();
 
   const fixedFee = useFixedFee();
 
@@ -92,6 +94,7 @@ function Component({ className }: BAssetClaimProps) {
                   break;
                 case StreamStatus.DONE:
                   claimResult.clear();
+                  history.push('/basset');
                   break;
               }
             }}

--- a/app/src/pages/basset/components/Claimable.tsx
+++ b/app/src/pages/basset/components/Claimable.tsx
@@ -8,13 +8,13 @@ import {
   useBLunaWithdrawableAmount,
   useBorrowMarketQuery,
 } from '@anchor-protocol/app-provider';
-import { d2Formatter, formatUTokenDecimal2 } from '@libs/formatter';
+import { formatUTokenDecimal2 } from '@libs/formatter';
 import { FlatButton } from '@libs/neumorphism-ui/components/FlatButton';
 import { Section } from '@libs/neumorphism-ui/components/Section';
 import { horizontalRuler, verticalRuler } from '@libs/styled-neumorphism';
 import { IconSpan } from '@libs/neumorphism-ui/components/IconSpan';
 import { InfoTooltip } from '@libs/neumorphism-ui/components/InfoTooltip';
-import { CW20Addr, HumanAddr, Luna, u, UST } from '@libs/types';
+import { HumanAddr, Luna, u, UST } from '@libs/types';
 import { AnimateNumber } from '@libs/ui';
 import big, { Big } from 'big.js';
 import { Sub } from 'components/Sub';
@@ -32,7 +32,6 @@ import { CW20TokenDisplayInfo, CW20TokenDisplayInfos } from '@libs/app-fns';
 import { useCW20TokenDisplayInfosQuery } from '@libs/app-provider';
 import { useWallet } from '@terra-money/use-wallet';
 import { bAsset, moneyMarket } from '@anchor-protocol/types';
-import { DoughnutChart } from 'pages/dashboard/components/DoughnutChart';
 
 const Heading = (props: { title: string; tooltip: string }) => {
   const { title, tooltip } = props;
@@ -54,14 +53,14 @@ type BAssetClaimableRewardsPayload = [
   rewards: BAssetClaimableRewards,
 ];
 
-type RewardBreakdown = {
+export type RewardBreakdown = {
   tokenDisplay: CW20TokenDisplayInfo;
   tokenRewardUST: u<UST<big>>;
   tokenReward: u<bAsset<big>>;
   tokenPriceUST: u<UST<big>>;
 };
 
-type RewardsBreakdown = {
+export type RewardsBreakdown = {
   totalRewardsUST: u<UST<big>>;
   rewardBreakdowns: RewardBreakdown[];
 };
@@ -122,13 +121,6 @@ const bAssetRewardsBreakdown = (
   });
 };
 
-type TokenMetadata = { [symbol: string]: { color: string } };
-
-const tokenMetadataBySymbol: TokenMetadata = {
-  bLuna: { color: '#4bdb4b' },
-  bETH: { color: '#1f1f1f' },
-};
-
 const useRewardsBreakdown = (
   oraclePrices: moneyMarket.oracle.PricesResponse['prices'],
   tokenDisplayInfos: CW20TokenDisplayInfos,
@@ -177,18 +169,6 @@ const useRewardsBreakdown = (
   }, [bAssetBreakdown, bLunaBreakdown]);
 };
 
-const defaultRewardBreakdown = (symbol: string): RewardBreakdown => ({
-  tokenDisplay: {
-    symbol,
-    protocol: '',
-    token: '' as CW20Addr,
-    icon: '',
-  },
-  tokenPriceUST: big(0) as u<UST<Big>>,
-  tokenReward: big(0) as u<bAsset<Big>>,
-  tokenRewardUST: big(0) as u<UST<Big>>,
-});
-
 function Component({ className }: ClaimableProps) {
   const { data: { oraclePrices } = {} } = useBorrowMarketQuery();
   const { data: tokenDisplayInfos = {} } = useCW20TokenDisplayInfosQuery();
@@ -206,28 +186,6 @@ function Component({ className }: ClaimableProps) {
     [_withdrawableAmount?.withdrawable],
   );
 
-  const rewardChartDescriptors = useMemo(() => {
-    const rewardsBySymbol = rewardsBreakdown.rewardBreakdowns.reduce(
-      (acc, curr) => ({ ...acc, [curr.tokenDisplay.symbol]: curr }),
-      {} as { [k: string]: RewardBreakdown },
-    );
-
-    return Object.entries(tokenMetadataBySymbol).map(
-      ([tokenSymbol, tokenMetadata]) => {
-        const rewardBreakdown =
-          tokenSymbol in rewardsBySymbol
-            ? rewardsBySymbol[tokenSymbol]
-            : defaultRewardBreakdown(tokenSymbol);
-
-        return {
-          value: Number(formatUTokenDecimal2(rewardBreakdown.tokenRewardUST)),
-          label: rewardBreakdown.tokenDisplay.symbol,
-          color: tokenMetadata.color,
-        };
-      },
-    );
-  }, [rewardsBreakdown]);
-
   return (
     <Section className={className}>
       <div>
@@ -242,25 +200,6 @@ function Component({ className }: ClaimableProps) {
             </AnimateNumber>{' '}
             <Sub>UST</Sub>
           </p>
-          <div className="rewards">
-            <div className="rewardsChart">
-              <DoughnutChart descriptors={rewardChartDescriptors} />
-            </div>
-            <div className="rewardBreakdowns">
-              {rewardChartDescriptors.map((descriptor) => (
-                <div className="rewardBreakdown" key={descriptor.label}>
-                  <i style={{ backgroundColor: descriptor.color }} />
-                  <span className="rewardLabel">{descriptor.label}</span>
-                  <span className="rewardValue">
-                    <AnimateNumber format={d2Formatter}>
-                      {descriptor.value}
-                    </AnimateNumber>{' '}
-                    UST
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
         </div>
         <FlatButton component={Link} to="/basset/claim">
           Claim Rewards
@@ -309,56 +248,6 @@ const vRuler = css`
 `;
 
 const StyledComponent = styled(Component)`
-  .rewards {
-    margin-top: 10px;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-
-    .rewardsChart {
-      width: 50px;
-      height: 50px;
-      margin-right: 10px;
-    }
-
-    .rewardBreakdowns {
-      display: flex;
-      flex-direction: column;
-      font-size: 12px;
-      margin-bottom: auto;
-      margin-top: auto;
-
-      .rewardBreakdown:not(:first-child) {
-        margin-top: 5px;
-      }
-
-      .rewardBreakdown {
-        display: flex;
-        align-items: center;
-        font-weight: 500;
-        line-height: 1.5;
-
-        .rewardLabel {
-          color: ${({ theme }) => theme.dimTextColor};
-          width: 45px;
-        }
-
-        .rewardValue {
-          color: ${({ theme }) => theme.textColor};
-        }
-
-        i {
-          background-color: currentColor;
-          display: inline-block;
-          width: 10px;
-          height: 10px;
-          border-radius: 3px;
-          margin-right: 5px;
-        }
-      }
-    }
-  }
-
   > .NeuSection-content {
     padding: 50px 40px;
 

--- a/app/src/pages/basset/components/Claimable.tsx
+++ b/app/src/pages/basset/components/Claimable.tsx
@@ -1,20 +1,11 @@
-import {
-  AnchorContractAddress,
-  BAssetInfoWithDisplay,
-  useAnchorWebapp,
-  useBAssetClaimableRewardsTotalQuery,
-  useBAssetInfoListQuery,
-  useBLunaClaimableRewards,
-  useBLunaWithdrawableAmount,
-  useBorrowMarketQuery,
-} from '@anchor-protocol/app-provider';
+import { useBLunaWithdrawableAmount } from '@anchor-protocol/app-provider';
 import { formatUTokenDecimal2 } from '@libs/formatter';
 import { FlatButton } from '@libs/neumorphism-ui/components/FlatButton';
 import { Section } from '@libs/neumorphism-ui/components/Section';
 import { horizontalRuler, verticalRuler } from '@libs/styled-neumorphism';
 import { IconSpan } from '@libs/neumorphism-ui/components/IconSpan';
 import { InfoTooltip } from '@libs/neumorphism-ui/components/InfoTooltip';
-import { HumanAddr, Luna, u, UST } from '@libs/types';
+import { Luna, u } from '@libs/types';
 import { AnimateNumber } from '@libs/ui';
 import big, { Big } from 'big.js';
 import { Sub } from 'components/Sub';
@@ -23,15 +14,7 @@ import { fixHMR } from 'fix-hmr';
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-import { claimableRewards as _claimableRewards } from '../logics/claimableRewards';
-import {
-  BAssetClaimableRewards,
-  BLunaClaimableRewards,
-} from '@anchor-protocol/app-fns';
-import { CW20TokenDisplayInfo, CW20TokenDisplayInfos } from '@libs/app-fns';
-import { useCW20TokenDisplayInfosQuery } from '@libs/app-provider';
-import { useWallet } from '@terra-money/use-wallet';
-import { bAsset, moneyMarket } from '@anchor-protocol/types';
+import { useClaimableRewardsBreakdown } from '../hooks/useRewardsBreakdown';
 
 const Heading = (props: { title: string; tooltip: string }) => {
   const { title, tooltip } = props;
@@ -48,135 +31,8 @@ export interface ClaimableProps {
   className?: string;
 }
 
-type BAssetClaimableRewardsPayload = [
-  contract: HumanAddr,
-  rewards: BAssetClaimableRewards,
-];
-
-export type RewardBreakdown = {
-  tokenDisplay: CW20TokenDisplayInfo;
-  tokenRewardUST: u<UST<big>>;
-  tokenReward: u<bAsset<big>>;
-  tokenPriceUST: u<UST<big>>;
-};
-
-export type RewardsBreakdown = {
-  totalRewardsUST: u<UST<big>>;
-  rewardBreakdowns: RewardBreakdown[];
-};
-
-const bLunaRewardBreakdown = (
-  oraclePrices: moneyMarket.oracle.PricesResponse['prices'],
-  contractAddress: AnchorContractAddress,
-  tokenDisplayInfos: { [addr: string]: CW20TokenDisplayInfo },
-  claimableRewards?: BLunaClaimableRewards,
-): RewardBreakdown => {
-  const tokenPriceUST = big(
-    oraclePrices.find((p) => p.asset === contractAddress.cw20.bLuna)?.price ??
-      0,
-  ) as u<UST<big>>;
-
-  const tokenRewardUST = _claimableRewards(
-    claimableRewards?.claimableReward,
-    claimableRewards?.rewardState,
-  );
-
-  return {
-    tokenDisplay: tokenDisplayInfos[contractAddress.cw20.bLuna],
-    tokenRewardUST,
-    tokenPriceUST,
-    tokenReward: (!tokenPriceUST.eq(big(0))
-      ? tokenRewardUST.div(tokenPriceUST)
-      : big(0)) as u<bAsset<big>>,
-  };
-};
-
-const bAssetRewardsBreakdown = (
-  oraclePrices: moneyMarket.oracle.PricesResponse['prices'],
-  bAssetInfoList: BAssetInfoWithDisplay[],
-  bAssetRewards: BAssetClaimableRewardsPayload[],
-): RewardBreakdown[] => {
-  return bAssetInfoList.map((b) => {
-    const rewardPayload = bAssetRewards.find(
-      (r) => r[0] === b.custodyConfig.reward_contract,
-    );
-
-    const tokenRewardUST = big(
-      rewardPayload ? rewardPayload[1].claimableReward.rewards : 0,
-    ) as u<UST<big>>;
-
-    const tokenPriceUST = big(
-      oraclePrices.find((p) => p.asset === b.bAsset.collateral_token)?.price ??
-        0,
-    ) as u<UST<big>>;
-
-    return {
-      tokenDisplay: b.tokenDisplay.anchor,
-      tokenRewardUST,
-      tokenPriceUST,
-      tokenReward: (!tokenPriceUST.eq(0)
-        ? tokenRewardUST.div(tokenPriceUST)
-        : big(0)) as u<bAsset<big>>,
-    };
-  });
-};
-
-const useRewardsBreakdown = (
-  oraclePrices: moneyMarket.oracle.PricesResponse['prices'],
-  tokenDisplayInfos: CW20TokenDisplayInfos,
-): RewardsBreakdown => {
-  const { data: bAssetInfoList = [] } = useBAssetInfoListQuery();
-  const { data: { rewards: bAssetRewards = [] } = {} } =
-    useBAssetClaimableRewardsTotalQuery();
-
-  const { network } = useWallet();
-  const { contractAddress } = useAnchorWebapp();
-  const { data: bLunaClaimableRewards } = useBLunaClaimableRewards();
-
-  const bLunaBreakdown = useMemo(
-    () =>
-      bLunaRewardBreakdown(
-        oraclePrices,
-        contractAddress,
-        tokenDisplayInfos[network.name] ?? {},
-        bLunaClaimableRewards,
-      ),
-    [
-      oraclePrices,
-      contractAddress,
-      tokenDisplayInfos,
-      network,
-      bLunaClaimableRewards,
-    ],
-  );
-
-  const bAssetBreakdown = useMemo(
-    () => bAssetRewardsBreakdown(oraclePrices, bAssetInfoList, bAssetRewards),
-    [oraclePrices, bAssetInfoList, bAssetRewards],
-  );
-
-  return useMemo(() => {
-    const rewardBreakdowns = [bLunaBreakdown, ...bAssetBreakdown];
-
-    return {
-      totalRewardsUST: rewardBreakdowns
-        .map((r) => r.tokenRewardUST)
-        .reduce((acc, curr) => acc.plus(curr), big(0)) as u<UST<big>>,
-      rewardBreakdowns: rewardBreakdowns.filter(
-        (r) => !r.tokenRewardUST.eq(big(0)),
-      ),
-    };
-  }, [bAssetBreakdown, bLunaBreakdown]);
-};
-
 function Component({ className }: ClaimableProps) {
-  const { data: { oraclePrices } = {} } = useBorrowMarketQuery();
-  const { data: tokenDisplayInfos = {} } = useCW20TokenDisplayInfosQuery();
-
-  const rewardsBreakdown = useRewardsBreakdown(
-    oraclePrices?.prices ?? [],
-    tokenDisplayInfos,
-  );
+  const { totalRewardsUST } = useClaimableRewardsBreakdown();
 
   const { data: { withdrawableUnbonded: _withdrawableAmount } = {} } =
     useBLunaWithdrawableAmount();
@@ -196,7 +52,7 @@ function Component({ className }: ClaimableProps) {
           />
           <p>
             <AnimateNumber format={formatUTokenDecimal2}>
-              {rewardsBreakdown.totalRewardsUST}
+              {totalRewardsUST}
             </AnimateNumber>{' '}
             <Sub>UST</Sub>
           </p>

--- a/app/src/pages/basset/components/ClaimableRewardBreakdown.tsx
+++ b/app/src/pages/basset/components/ClaimableRewardBreakdown.tsx
@@ -1,13 +1,16 @@
-import { CW20Addr, u, UST } from '@libs/types';
+import { CW20Addr, HumanAddr, u, UST } from '@libs/types';
 import big, { Big } from 'big.js';
 import { bAsset } from '@anchor-protocol/types';
-import { RewardBreakdown, RewardsBreakdown } from './Claimable';
 import React, { useMemo } from 'react';
 import { d2Formatter, formatUTokenDecimal2 } from '@libs/formatter';
 import { AnimateNumber } from '@libs/ui';
 import { DoughnutChart } from 'pages/dashboard/components/DoughnutChart';
 import styled from 'styled-components';
 import { fixHMR } from 'fix-hmr';
+import {
+  RewardBreakdown,
+  RewardsBreakdown,
+} from '../hooks/useRewardsBreakdown';
 
 type ClaimableRewardsBreakdownProps = {
   rewardsBreakdown: RewardsBreakdown;
@@ -31,6 +34,7 @@ const defaultRewardBreakdown = (symbol: string): RewardBreakdown => ({
   tokenPriceUST: big(0) as u<UST<Big>>,
   tokenReward: big(0) as u<bAsset<Big>>,
   tokenRewardUST: big(0) as u<UST<Big>>,
+  rewardAddr: '' as HumanAddr,
 });
 
 const Component = ({

--- a/app/src/pages/basset/components/ClaimableRewardBreakdown.tsx
+++ b/app/src/pages/basset/components/ClaimableRewardBreakdown.tsx
@@ -1,0 +1,139 @@
+import { CW20Addr, u, UST } from '@libs/types';
+import big, { Big } from 'big.js';
+import { bAsset } from '@anchor-protocol/types';
+import { RewardBreakdown, RewardsBreakdown } from './Claimable';
+import React, { useMemo } from 'react';
+import { d2Formatter, formatUTokenDecimal2 } from '@libs/formatter';
+import { AnimateNumber } from '@libs/ui';
+import { DoughnutChart } from 'pages/dashboard/components/DoughnutChart';
+import styled from 'styled-components';
+import { fixHMR } from 'fix-hmr';
+
+type ClaimableRewardsBreakdownProps = {
+  rewardsBreakdown: RewardsBreakdown;
+  className?: string;
+};
+
+type TokenMetadata = { [symbol: string]: { color: string } };
+
+const tokenMetadataBySymbol: TokenMetadata = {
+  bLuna: { color: '#4bdb4b' },
+  bETH: { color: '#1f1f1f' },
+};
+
+const defaultRewardBreakdown = (symbol: string): RewardBreakdown => ({
+  tokenDisplay: {
+    symbol,
+    protocol: '',
+    token: '' as CW20Addr,
+    icon: '',
+  },
+  tokenPriceUST: big(0) as u<UST<Big>>,
+  tokenReward: big(0) as u<bAsset<Big>>,
+  tokenRewardUST: big(0) as u<UST<Big>>,
+});
+
+const Component = ({
+  rewardsBreakdown,
+  className,
+}: ClaimableRewardsBreakdownProps) => {
+  const rewardChartDescriptors = useMemo(() => {
+    const rewardsBySymbol = rewardsBreakdown.rewardBreakdowns.reduce(
+      (acc, curr) => ({ ...acc, [curr.tokenDisplay.symbol]: curr }),
+      {} as { [k: string]: RewardBreakdown },
+    );
+
+    return Object.entries(tokenMetadataBySymbol).map(
+      ([tokenSymbol, tokenMetadata]) => {
+        const rewardBreakdown =
+          tokenSymbol in rewardsBySymbol
+            ? rewardsBySymbol[tokenSymbol]
+            : defaultRewardBreakdown(tokenSymbol);
+
+        return {
+          value: Number(formatUTokenDecimal2(rewardBreakdown.tokenRewardUST)),
+          label: rewardBreakdown.tokenDisplay.symbol,
+          color: tokenMetadata.color,
+        };
+      },
+    );
+  }, [rewardsBreakdown]);
+
+  return (
+    <div className={className}>
+      <div className="rewards">
+        <div className="rewardsChart">
+          <DoughnutChart descriptors={rewardChartDescriptors} />
+        </div>
+        <div className="rewardBreakdowns">
+          {rewardChartDescriptors.map((descriptor) => (
+            <div className="rewardBreakdown" key={descriptor.label}>
+              <i style={{ backgroundColor: descriptor.color }} />
+              <span className="rewardLabel">{descriptor.label}</span>
+              <span className="rewardValue">
+                <AnimateNumber format={d2Formatter}>
+                  {descriptor.value}
+                </AnimateNumber>{' '}
+                UST
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const StyledComponent = styled(Component)`
+  .rewards {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    .rewardsChart {
+      width: 50px;
+      height: 50px;
+      margin-right: 10px;
+    }
+
+    .rewardBreakdowns {
+      display: flex;
+      flex-direction: column;
+      font-size: 12px;
+      margin-bottom: auto;
+      margin-top: auto;
+
+      .rewardBreakdown:not(:first-child) {
+        margin-top: 5px;
+      }
+
+      .rewardBreakdown {
+        display: flex;
+        align-items: center;
+        font-weight: 500;
+        line-height: 1.5;
+
+        .rewardLabel {
+          color: ${({ theme }) => theme.dimTextColor};
+          width: 45px;
+        }
+
+        .rewardValue {
+          color: ${({ theme }) => theme.textColor};
+        }
+
+        i {
+          background-color: currentColor;
+          display: inline-block;
+          width: 10px;
+          height: 10px;
+          border-radius: 3px;
+          margin-right: 5px;
+        }
+      }
+    }
+  }
+`;
+
+export const ClaimableRewardsBreakdown = fixHMR(StyledComponent);

--- a/app/src/pages/basset/hooks/useRewardsBreakdown.ts
+++ b/app/src/pages/basset/hooks/useRewardsBreakdown.ts
@@ -1,0 +1,152 @@
+import {
+  BAssetClaimableRewards,
+  BLunaClaimableRewards,
+} from '@anchor-protocol/app-fns';
+import {
+  AnchorContractAddress,
+  BAssetInfoWithDisplay,
+  useAnchorWebapp,
+  useBAssetClaimableRewardsTotalQuery,
+  useBAssetInfoListQuery,
+  useBLunaClaimableRewards,
+  useBorrowMarketQuery,
+} from '@anchor-protocol/app-provider';
+import { bAsset, moneyMarket } from '@anchor-protocol/types';
+import { CW20TokenDisplayInfo, CW20TokenDisplayInfos } from '@libs/app-fns';
+import { useCW20TokenDisplayInfosQuery } from '@libs/app-provider';
+import { HumanAddr, u, UST } from '@libs/types';
+import { useWallet } from '@terra-money/use-wallet';
+import big from 'big.js';
+import { useMemo } from 'react';
+import { claimableRewards as _claimableRewards } from '../logics/claimableRewards';
+
+type BAssetClaimableRewardsPayload = [
+  contract: HumanAddr,
+  rewards: BAssetClaimableRewards,
+];
+
+export type RewardBreakdown = {
+  tokenDisplay: CW20TokenDisplayInfo;
+  tokenRewardUST: u<UST<big>>;
+  tokenReward: u<bAsset<big>>;
+  tokenPriceUST: u<UST<big>>;
+  rewardAddr: HumanAddr;
+};
+
+export type RewardsBreakdown = {
+  totalRewardsUST: u<UST<big>>;
+  rewardBreakdowns: RewardBreakdown[];
+};
+
+const bLunaRewardBreakdown = (
+  oraclePrices: moneyMarket.oracle.PricesResponse['prices'],
+  contractAddress: AnchorContractAddress,
+  tokenDisplayInfos: { [addr: string]: CW20TokenDisplayInfo },
+  claimableRewards?: BLunaClaimableRewards,
+): RewardBreakdown => {
+  const tokenPriceUST = big(
+    oraclePrices.find((p) => p.asset === contractAddress.cw20.bLuna)?.price ??
+      0,
+  ) as u<UST<big>>;
+
+  const tokenRewardUST = _claimableRewards(
+    claimableRewards?.claimableReward,
+    claimableRewards?.rewardState,
+  );
+
+  return {
+    tokenDisplay: tokenDisplayInfos[contractAddress.cw20.bLuna],
+    tokenRewardUST,
+    tokenPriceUST,
+    tokenReward: (tokenPriceUST.gt(big(0))
+      ? tokenRewardUST.div(tokenPriceUST)
+      : big(0)) as u<bAsset<big>>,
+    rewardAddr: contractAddress.bluna.reward,
+  };
+};
+
+const bAssetRewardsBreakdown = (
+  oraclePrices: moneyMarket.oracle.PricesResponse['prices'],
+  bAssetInfoList: BAssetInfoWithDisplay[],
+  bAssetRewards: BAssetClaimableRewardsPayload[],
+): RewardBreakdown[] => {
+  return bAssetInfoList.map((b) => {
+    const rewardPayload = bAssetRewards.find(
+      (r) => r[0] === b.custodyConfig.reward_contract,
+    );
+
+    const tokenRewardUST = big(
+      rewardPayload ? rewardPayload[1].claimableReward.rewards : 0,
+    ) as u<UST<big>>;
+
+    const tokenPriceUST = big(
+      oraclePrices.find((p) => p.asset === b.bAsset.collateral_token)?.price ??
+        0,
+    ) as u<UST<big>>;
+
+    return {
+      tokenDisplay: b.tokenDisplay.anchor,
+      tokenRewardUST,
+      tokenPriceUST,
+      tokenReward: (tokenPriceUST.gt(big(0))
+        ? tokenRewardUST.div(tokenPriceUST)
+        : big(0)) as u<bAsset<big>>,
+      rewardAddr: b.custodyConfig.reward_contract,
+    };
+  });
+};
+
+const useRewardsBreakdown = (
+  oraclePrices: moneyMarket.oracle.PricesResponse['prices'],
+  tokenDisplayInfos: CW20TokenDisplayInfos,
+): RewardsBreakdown => {
+  const { data: bAssetInfoList = [] } = useBAssetInfoListQuery();
+  const { data: { rewards: bAssetRewards = [] } = {} } =
+    useBAssetClaimableRewardsTotalQuery();
+
+  const { network } = useWallet();
+  const { contractAddress } = useAnchorWebapp();
+  const { data: bLunaClaimableRewards } = useBLunaClaimableRewards();
+
+  const bLunaBreakdown = useMemo(
+    () =>
+      bLunaRewardBreakdown(
+        oraclePrices,
+        contractAddress,
+        tokenDisplayInfos[network.name] ?? {},
+        bLunaClaimableRewards,
+      ),
+    [
+      oraclePrices,
+      contractAddress,
+      tokenDisplayInfos,
+      network,
+      bLunaClaimableRewards,
+    ],
+  );
+
+  const bAssetBreakdown = useMemo(
+    () => bAssetRewardsBreakdown(oraclePrices, bAssetInfoList, bAssetRewards),
+    [oraclePrices, bAssetInfoList, bAssetRewards],
+  );
+
+  return useMemo(() => {
+    const rewardBreakdowns = [bLunaBreakdown, ...bAssetBreakdown];
+
+    return {
+      totalRewardsUST: rewardBreakdowns
+        .map((r) => r.tokenRewardUST)
+        .reduce((acc, curr) => acc.plus(curr), big(0)) as u<UST<big>>,
+      rewardBreakdowns: rewardBreakdowns.filter((r) =>
+        r.tokenRewardUST.gt(big(0)),
+      ),
+    };
+  }, [bAssetBreakdown, bLunaBreakdown]);
+};
+
+export const useClaimableRewardsBreakdown = () => {
+  const { data: { oraclePrices } = {} } = useBorrowMarketQuery();
+  const { data: tokenDisplayInfos = {} } = useCW20TokenDisplayInfosQuery();
+
+  return useRewardsBreakdown(oraclePrices?.prices ?? [], tokenDisplayInfos);
+};


### PR DESCRIPTION
Changes include:
- Extract claimable rewards breakdown chart display to a separate component for later reuse.
- Remove claimable rewards breakdown from bAsset page.
- Extract useClaimableRewards into a separate hook.
- Refactor claim tx flow to work with reward breakdowns. 
- Add reward breakdown by bAsset display to successful claim tx screen.
- Add redirect to basset page to successful claim tx flow.