### PR TITLE
fix(label): remove voting rewards misinformation

### DIFF
--- a/app/src/pages/mypage/components/TotalValue.tsx
+++ b/app/src/pages/mypage/components/TotalValue.tsx
@@ -172,7 +172,7 @@ function TotalValueBase({ className }: TotalValueProps) {
         },
         {
           label: 'Govern',
-          tooltip: 'Total value of staked ANC and unclaimed voting rewards',
+          tooltip: 'Total value of staked ANC',
           amount: govern,
         },
       ],


### PR DESCRIPTION
Hey there! 👋🏻 

The tooltip announces voting rewards that do not exist (at least, now).
It currently creates confusion across the community.

(Note: This has been discussed internally with the moderators)